### PR TITLE
chore: use new circleci docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 docker: &DOCKER_NODE
   docker:
-    - image: circleci/node:10.22
+    - image: cimg/node:lts
 
 jobs:
   install:


### PR DESCRIPTION
potentially speeds up builds