### PR TITLE
correct phraseapp format in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Create a .phraseapp.yml:
 ```
 phraseapp:
   project_id: <your project id>
-  file_format: json
+  file_format: nested_json
 
   push:
     sources:


### PR DESCRIPTION
`json` is not a valid format, but `nested_json` is