### PR TITLE
fix: executables

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "cfy-phraseapp": "./pkg/index.js"
   },
   "files": [
-    "pkg/**/*"
+    "pkg/**/*",
+    "bin/phraseapp"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Phraseapp workflow",
   "scripts": {
     "test": "sh test.sh",
-    "build": "rimraf pkg && tsc --outDir pkg",
+    "build": "rimraf pkg && tsc --outDir pkg && chmod +x pkg/index.js",
     "lint": "eslint --ext ts,js,tsx,jsx,json .",
     "format": "npm run lint -- --fix",
     "typecheck": "tsc --noEmit"

--- a/src/cli/push.ts
+++ b/src/cli/push.ts
@@ -9,7 +9,7 @@ export default () => {
   }
 
   const bin = process.env.CI
-    ? path.resolve(__dirname, "../../bin/phraseapp")
+    ? path.resolve(__dirname, "./bin/phraseapp")
     : "phraseapp"
 
   const pushOutput = execSync(

--- a/src/cli/push.ts
+++ b/src/cli/push.ts
@@ -9,7 +9,7 @@ export default () => {
   }
 
   const bin = process.env.CI
-    ? path.resolve(__dirname, "./bin/phraseapp")
+    ? path.resolve(__dirname, "../bin/phraseapp")
     : "phraseapp"
 
   const pushOutput = execSync(

--- a/src/cli/push.ts
+++ b/src/cli/push.ts
@@ -9,7 +9,7 @@ export default () => {
   }
 
   const bin = process.env.CI
-    ? path.resolve(__dirname, "../bin/phraseapp")
+    ? path.resolve(__dirname, "../../bin/phraseapp")
     : "phraseapp"
 
   const pushOutput = execSync(


### PR DESCRIPTION
```
/bin/sh: 1: /home/circleci/project/node_modules/@*********/phraseapp/bin/phraseapp: not found
```

on an npm publish, a file filter `"files": ["pkg/**/*"]` is applied and `bin` obviously is not a part of that. the build script does not push the binary to the `pkg` folder. unfortunately this filter is not applied when `npm link`ing locally, which is what I tested with. a local execution also does not refer to the `bin/phraseapp`, but a system-wide instance. I'm not sure yet how this was working on CI on the branch...